### PR TITLE
Code Coverage implemented with Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ before_script:
 script:
   - ./gradlew clean 
   - ./gradlew check
-  - ./gradlew codeCoverageReport
 after_success:
   - bush <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: java
 jdk:
   - oraclejdk8
-before_script:
-  - chmod +x gradlew
+
+sudo: false # faster builds
+
+before_install:
+  - pip install --user codecov
+
 script:
   - ./gradlew clean 
   - ./gradlew check
+
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: java
 jdk:
   - oraclejdk8
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
 script:
   - ./gradlew clean 
   - ./gradlew check

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_script:
 script:
   - ./gradlew clean 
   - ./gradlew check
+  - ./gradlew codeCoverageReport
 after_success:
   - bush <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script:
   - ./gradlew clean 
   - ./gradlew check
 after_success:
-  - bush <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: java
-
 jdk:
   - oraclejdk8
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
+before_script:
+  - chmod +x gradlew
 script:
   - ./gradlew clean 
   - ./gradlew check
+  - ./gradlew codeCoverageReport
+after_success:
+  - bush <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 script:
   - ./gradlew clean 
   - ./gradlew check
+  - ./gradlew jacocTestReport
 
 after_success:
   - codecov

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
 apply plugin: 'application'
+apply plugin: 'jacoco'
 
 mainClassName = "is.ru.tictactoe.Game"
 
@@ -25,13 +26,16 @@ dependencies {
     // The production code uses the SLF4J logging API at compile time
     compile 'org.slf4j:slf4j-api:1.7.21'
 
-    // Declare the dependency for your favourite test framework you want to use in your tests.
-    // TestNG is also supported by the Gradle Test task. Just change the
-    // testCompile dependency to testCompile 'org.testng:testng:6.8.1' and add
-    // 'test.useTestNG()' to your build script.
     testCompile 'junit:junit:4.12'
 }
 
 task stage {
     dependsOn installDist
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled false
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,25 +36,6 @@ task stage {
 jacocoTestReport {
     reports {
         xml.enabled true
-        html.enabled false
     }
 }
 
-task codeCoverageReport(type: JacocoReport) {
-    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
-
-    subprojects.each {
-        sourceSets it.sourceSets.main
-    }
-
-    reports {
-        xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/report.xml"
-        html.enabled false
-        csv.enabled false
-    }
-}
-
-codeCoverageReport.dependsOn {
-    subprojects*.test
-}

--- a/build.gradle
+++ b/build.gradle
@@ -39,3 +39,22 @@ jacocoTestReport {
         html.enabled false
     }
 }
+
+task codeCoverageReport(type: JacocoReport) {
+    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+
+    subprojects.each {
+        sourceSets it.sourceSets.main
+    }
+
+    reports {
+        xml.enabled true
+        xml.destination "${buildDir}/reports/jacoco/report.xml"
+        html.enabled false
+        csv.enabled false
+    }
+}
+
+codeCoverageReport.dependsOn {
+    subprojects*.test
+}


### PR DESCRIPTION
Code coverage implemented with Codecov. Changed .travis.yml and build.gradle to make this happen.

Implemented use of Jacoco, which is included in Gradle. 
Made Gradle make a Jacoco report. 
Install and run Codecov in Travis.
